### PR TITLE
Fix the caching arguments

### DIFF
--- a/acdc/main.py
+++ b/acdc/main.py
@@ -140,8 +140,8 @@ parser = argparse.ArgumentParser(description="Used to launch ACDC runs. Only tas
 task_choices = ['ioi', 'docstring', 'induction', 'tracr-reverse', 'tracr-proportion', 'greaterthan']
 parser.add_argument('--task', type=str, required=True, choices=task_choices, help=f'Choose a task from the available options: {task_choices}')
 parser.add_argument('--threshold', type=float, required=True, help='Value for THRESHOLD')
-parser.add_argument('--first-cache-cpu', type=bool, required=False, default=True, help='Value for FIRST_CACHE_CPU')
-parser.add_argument('--second-cache-cpu', type=bool, required=False, default=True, help='Value for SECOND_CACHE_CPU')
+parser.add_argument('--first-cache-cpu', type=str, required=False, default="True", help='Value for FIRST_CACHE_CPU')
+parser.add_argument('--second-cache-cpu', type=str, required=False, default="True", help='Value for SECOND_CACHE_CPU')
 parser.add_argument('--zero-ablation', action='store_true', help='Use zero ablation')
 parser.add_argument('--using-wandb', action='store_true', help='Use wandb')
 parser.add_argument('--wandb-entity-name', type=str, required=False, default="remix_school-of-rock", help='Value for WANDB_ENTITY_NAME')
@@ -183,8 +183,18 @@ if args.torch_num_threads > 0:
 torch.manual_seed(args.seed)
 
 TASK = args.task
-FIRST_CACHE_CPU = args.first_cache_cpu
-SECOND_CACHE_CPU = args.second_cache_cpu
+if args.first_cache_cpu is None:
+    FIRST_CACHE_CPU = True
+elif args.first_cache_cpu.lower() == "false":
+    FIRST_CACHE_CPU = False
+else: 
+    raise ValueError(f"first_cache_cpu must be either True or False, got {args.first_cache_cpu}")
+if args.second_cache_cpu is None:
+    SECOND_CACHE_CPU = True
+elif args.second_cache_cpu.lower() == "false":
+    SECOND_CACHE_CPU = False
+else:
+    raise ValueError(f"second_cache_cpu must be either True or False, got {args.second_cache_cpu}")
 THRESHOLD = args.threshold  # only used if >= 0.0
 ZERO_ABLATION = True if args.zero_ablation else False
 USING_WANDB = True if args.using_wandb else False

--- a/acdc/main.py
+++ b/acdc/main.py
@@ -183,16 +183,20 @@ if args.torch_num_threads > 0:
 torch.manual_seed(args.seed)
 
 TASK = args.task
-if args.first_cache_cpu is None:
+if args.first_cache_cpu is None: # manage default
     FIRST_CACHE_CPU = True
 elif args.first_cache_cpu.lower() == "false":
     FIRST_CACHE_CPU = False
+elif args.first_cache_cpu.lower() == "true":
+    FIRST_CACHE_CPU = True
 else: 
     raise ValueError(f"first_cache_cpu must be either True or False, got {args.first_cache_cpu}")
 if args.second_cache_cpu is None:
     SECOND_CACHE_CPU = True
 elif args.second_cache_cpu.lower() == "false":
     SECOND_CACHE_CPU = False
+elif args.second_cache_cpu.lower() == "true":
+    SECOND_CACHE_CPU = True
 else:
     raise ValueError(f"second_cache_cpu must be either True or False, got {args.second_cache_cpu}")
 THRESHOLD = args.threshold  # only used if >= 0.0


### PR DESCRIPTION
The old `main.py` script would *always* have the caches on CPUs, no matter the inputs. 

No difference to results but likely will speed up some scripts. 

GPT-4 found this when reviewing totally different code I wrote...
![Selection_800](https://github.com/ArthurConmy/Automatic-Circuit-Discovery/assets/35957051/ef13d415-a48c-405b-9c7b-02fb41dc7c3d)
(it's better to use type string so old commands now are executed correctly)