### PR TITLE
iterative_correspondence_from_mask optimisation

### DIFF
--- a/acdc/greaterthan/utils.py
+++ b/acdc/greaterthan/utils.py
@@ -229,9 +229,9 @@ CIRCUIT = {
 }
 
 def get_greaterthan_true_edges(model):
-    from subnetwork_probing.train import correspondence_from_mask
+    from subnetwork_probing.train import iterative_correspondence_from_mask
 
-    corr = correspondence_from_mask(
+    corr, _ = iterative_correspondence_from_mask(
         model=model,
         nodes_to_mask = [],
     )

--- a/acdc/ioi/utils.py
+++ b/acdc/ioi/utils.py
@@ -218,8 +218,8 @@ def get_ioi_true_edges(model):
                     )
 
 
-    from subnetwork_probing.train import correspondence_from_mask
-    corr = correspondence_from_mask(
+    from subnetwork_probing.train import iterative_correspondence_from_mask
+    corr, _ = iterative_correspondence_from_mask(
         nodes_to_mask=nodes_to_mask,
         model = model,
     )

--- a/experiments/launch_sixteen_heads.py
+++ b/experiments/launch_sixteen_heads.py
@@ -47,7 +47,7 @@ from acdc.ioi.utils import get_all_ioi_things
 from acdc.TLACDCExperiment import TLACDCExperiment
 from acdc.TLACDCInterpNode import TLACDCInterpNode, heads_to_nodes_to_mask
 from acdc.tracr_task.utils import get_all_tracr_things
-from subnetwork_probing.train import correspondence_from_mask
+from subnetwork_probing.train import iterative_correspondence_from_mask
 from notebooks.emacs_plotly_render import set_plotly_renderer
 
 from subnetwork_probing.transformer_lens.transformer_lens.HookedTransformer import HookedTransformer as SPHookedTransformer
@@ -286,9 +286,10 @@ if args.zero_ablation:
     do_zero_caching(model)
 
 nodes_to_mask = []
+corr, head_parents = None, None
 for nodes, hook_name, idx in tqdm.tqdm(nodes_names_indices):
     nodes_to_mask += nodes
-    corr = correspondence_from_mask(model, nodes_to_mask, use_pos_embed=False, newv=False)
+    corr, head_parents = iterative_correspondence_from_mask(model, nodes_to_mask, use_pos_embed=False, newv=False, corr=corr, head_parents=head_parents)
     for e in corr.all_edges().values():
         e.effect_size = 1.0
 

--- a/tests/subnetwork_probing/test_count_nodes.py
+++ b/tests/subnetwork_probing/test_count_nodes.py
@@ -15,7 +15,7 @@ import sys
 
 sys.path.append(str(Path(__file__).parent.parent / "code"))
 
-from subnetwork_probing.train import correspondence_from_mask, get_transformer_config
+from subnetwork_probing.train import iterative_correspondence_from_mask, get_transformer_config
 import networkx as nx
 from acdc.TLACDCInterpNode import parse_interpnode
 
@@ -137,5 +137,5 @@ def test_count_nodes():
             g2.remove_edge(n, n)
     assert len(g2.edges) == 41
 
-    corr = correspondence_from_mask(model, nodes_to_mask)
+    corr, _ = iterative_correspondence_from_mask(model, nodes_to_mask)
     assert corr.count_no_edges() == 41


### PR DESCRIPTION
Change correspondence_from_mask to iterative_correspondence_from_mask for >10x speeding running launch_sixteen_heads and roc_plot_generator on sixteen heads and subnetwork probing.