### PR TITLE
Add back the png saving

### DIFF
--- a/acdc/acdc_graphics.py
+++ b/acdc/acdc_graphics.py
@@ -190,6 +190,10 @@ def show(
                     g2.add_edge(s[i], s[j], style="invis", weight=200)
             g2.write(path=base_path / f"{k}.gv")
         g.write(path=base_fname + ".gv")
+
+        if not fname.endswith(".gv"): # turn the .gv file into a .png file
+            g.draw(path=fname, prog="dot")
+
     return g
 
 # -------------------------------------------


### PR DESCRIPTION
@rhaps0dy I think https://github.com/ArthurConmy/Automatic-Circuit-Discovery/pull/70 removed the option for `show` to produce `.png`s. This is essential for e.g the notebook. 

Let me know if you think this logic (file name not ending with `.gv`) is appropriate

[From what I can see, [the three uses in the repo](https://github.com/ArthurConmy/Automatic-Circuit-Discovery/blob/dc777bd/notebooks/roc_plot_generator.py#L451#L472) of `show` that probably **don't want** generation of `png` files include the `gv` extensions, so I don't think that this breaks anything]