### PR TITLE
Remove duplicated and mis-indented code

### DIFF
--- a/subnetwork_probing/train.py
+++ b/subnetwork_probing/train.py
@@ -80,9 +80,6 @@ def iterative_correspondence_from_mask(
 
     assert all([v <= 3 for v in head_parents.values()]), "We should have at most three parents (Q, K and V, connected via placeholders)"
 
-        if node.name.endswith(("mlp_in", "resid_mid")):
-            additional_nodes_to_mask.append(TLACDCInterpNode(node.name.replace("resid_mid", "mlp_out").replace("mlp_in", "mlp_out"), node.index, EdgeType.DIRECT_COMPUTATION))
-
     for node in nodes_to_mask + additional_nodes_to_mask:
         # Mark edges where this is child as not present
         rest2 = corr.edges[node.name][node.index]


### PR DESCRIPTION
Removes a piece of code that is wrongly indented and also appears a few lines earlier (lines 73-79 in the same file).